### PR TITLE
Add labs support contact details

### DIFF
--- a/origami.json
+++ b/origami.json
@@ -4,6 +4,10 @@
 	"origamiVersion": 1,
 	"support": "https://github.com/ftlabs/o-crossword/issues",
 	"supportStatus": "experimental",
+	"supportContact": {
+		"email": "ftlabs@ft.com",
+		"slack": "financialtimes/ftlabs"
+	},
 	"ci": {
 		"circle": "https://circleci.com/api/v1/project/ftlabs/o-crossword"
 	},


### PR DESCRIPTION
This allows the new registry to display a warning that the component isn't necessarily maintained