### PR TITLE
Update o-viewport version

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -4,7 +4,7 @@
     "o-colors": "^4.1.5",
     "o-grid": "^4.0.6",
     "o-typography": "^5.4.1",
-    "o-viewport": "^2.2.0",
+    "o-viewport": "^3.1.6",
     "o-tracking": "^1.3.5",
     "o-buttons": "^5.8.5"
   },


### PR DESCRIPTION
This doesn't add any value I am afraid but it will fix a version conflict in the app repo.

There doesn't seem to be any breaking change in the [diff](https://github.com/Financial-Times/o-viewport/compare/v2.2.0...master) but I have tested the component locally anyway.