### PR TITLE
Update support status to "dead".

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # o-crossword
 
-An experimental Origami component to implement a responsive crossword.
+Deprecated: There is no direct Origami replacement. Formally: An experimental Origami component to implement a responsive crossword.
 
 ## To build this locally
 

--- a/origami.json
+++ b/origami.json
@@ -3,7 +3,7 @@
 	"origamiType": "module",
 	"origamiVersion": 1,
 	"support": "https://github.com/ftlabs/o-crossword/issues",
-	"supportStatus": "experimental",
+	"supportStatus": "dead",
 	"supportContact": {
 		"email": "ftlabs@ft.com",
 		"slack": "financialtimes/ftlabs"


### PR DESCRIPTION
This component was experimental and is no longer going to be use
in the app, as a third party is working on a new crossword solution.

Mark as dead:
>decommissioned entirely, will receive no support
https://origami.ft.com/documentation/manifests/origami-json/

o-crossword will not be moved to the origami mono-repo and
Build Service v3 support will not be added.

Still used on the labs site. To not break the web, let's store stale responses in the build serviec:
https://labs.ft.com/crosswords/
Relates to: https://github.com/Financial-Times/origami-build-service/issues/578

Closes: https://github.com/Financial-Times/o-crossword/issues/112